### PR TITLE
Use custom FfmpegError when command fails

### DIFF
--- a/lib/ffmpeg_command.js
+++ b/lib/ffmpeg_command.js
@@ -7,7 +7,8 @@ const { EventEmitter } = require('events');
 const config = require('./util/config')(),
   cp = require('child_process'),
   FFmpegInput = require('./ffmpeg_input'),
-  FFmpegOutput = require('./ffmpeg_output');
+  FFmpegOutput = require('./ffmpeg_output'),
+  FFmpegError = require('./ffmpeg_error');
 
 /**
  * Class representing an FFmpeg command (`ffmpeg ...`)
@@ -147,7 +148,9 @@ class FFmpegCommand extends EventEmitter {
     const cmd = this.toCommand();
     return new Promise(function (resolve, reject) {
       cp.execFile(cmd.command, cmd.args, (err, stdout, stderr) => {
-        if (err) { reject({ error: err, stderr: stderr, stdout: stdout }); return; }
+        if (err) {
+          return reject(new FFmpegError(err));
+        }
         resolve({ stderr: stderr, stdout: stdout });
       });
     });

--- a/lib/ffmpeg_error.js
+++ b/lib/ffmpeg_error.js
@@ -5,7 +5,7 @@
 class FFmpegError extends Error {
   constructor(error) {
     // last line of ffmpeg stderr usually contains most helpful error
-    super(error.message.split('\n').slice(-2, -1));
+    super(error.message.trim().split('\n').pop());
     this.name = this.constructor.name;
     this.code = error.code
     this.stderr = error.message;

--- a/lib/ffmpeg_error.js
+++ b/lib/ffmpeg_error.js
@@ -1,0 +1,19 @@
+/**
+ * @fileOverview lib/ffmpeg_error.js - Defines and exports the FFmpegError class
+ */
+
+class FFmpegError extends Error {
+  constructor(error) {
+    // last line of ffmpeg stderr usually contains most helpful error
+    super(error.message.split('\n').slice(-2, -1));
+    this.name = this.constructor.name;
+    this.code = error.code
+    this.stderr = error.message;
+    this.killed = error.killed;
+    this.signal = error.signal;
+    this.cmd = error.cmd;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = FFmpegError;

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -347,7 +347,7 @@ class FilterNode {
       /** Constant value representing a sink filter with only input(s) */
       SINK: 2,
     }
-  }  
+  }
 }
 
 /**

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -296,7 +296,7 @@ class FilterNode {
       ffmpeg_binary = ffmpeg_binary[0];
       ffmpeg_args = config.ffmpeg_bin.slice(1).concat(ffmpeg_args);
     }
-    const out = execFileSync(ffmpeg_binary, ffmpeg_args, {});
+    const out = execFileSync(ffmpeg_binary, ffmpeg_args, { stdio: 'pipe' });
     return out;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -577,6 +577,14 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -597,8 +605,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "cheerio": {
       "version": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "all-contributors-cli": "^6.9.1",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^5.8.0",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.6.3",

--- a/test/ffmpeg_error.test.js
+++ b/test/ffmpeg_error.test.js
@@ -1,0 +1,61 @@
+const chai = require('chai'),
+  expect = chai.expect,
+  sinon = require('sinon'),
+  fs = require('fs');
+
+const FFmpegError = require('../lib/ffmpeg_error');
+
+describe('FFmpegError', function () {
+  describe('constructor()', function () {
+    let originalError;
+    beforeEach(() => {
+      originalError = new Error('message');
+    });
+
+    it('creates an FFmpegError object', () => {
+      const error = new FFmpegError(originalError);
+      expect(error).to.be.instanceof(FFmpegError);
+    });
+
+    it('should set name on error object', () => {
+      const error = new FFmpegError(originalError);
+      expect(error.name).to.eql('FFmpegError');
+    });
+
+    it('creates an FFmpegError object with message last line of input message', () => {
+      originalError.message = 'first line\nsecond line\nlast line';
+      const error = new FFmpegError(originalError);
+      expect(error.message).to.eql('last line');
+    });
+
+    it('creates an FFmpegError object last line of input message disregarding whitespace', () => {
+      originalError.message = 'first line\nsecond line\nlast line\n';
+      const error = new FFmpegError(originalError);
+      expect(error.message).to.eql('last line');
+    });
+
+    it('creates an FFmpegError object with stderr set to original message', () => {
+      originalError.message = 'first line\nsecond line\nlast line';
+      const error = new FFmpegError(originalError);
+      expect(error.stderr).to.eql(originalError.message);
+    });
+
+    it('should copy some properties from the original object', () => {
+      originalError.killed = true;
+      originalError.signal = 'SIGINT';
+      originalError.code = 1;
+      originalError.cmd = 'ffmpeg -i';
+      const error = new FFmpegError(originalError);
+      expect(error.killed).to.eql(originalError.killed);
+      expect(error.signal).to.eql(originalError.signal);
+      expect(error.code).to.eql(originalError.code);
+      expect(error.cmd).to.eql(originalError.cmd);
+    });
+
+    it('should not copy other properties from the original object', () => {
+      originalError.sassafras = 'zeugma';
+      const error = new FFmpegError(originalError);
+      expect(error.sassafras).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
Current state:

When an unhandled error happens, we get this:

```
(node:83706) UnhandledPromiseRejectionWarning: #<Object>
```

With this change, we get a more helpful error without error checking:
```
(node:84017) UnhandledPromiseRejectionWarning: FFmpegError: File '/path/to/slop.mp4' already exists. Overwrite ? [y/N] Not overwriting - exiting
    at cp.execFile (/path/to/fessonia/lib/ffmpeg_command.js:152:25)
    at ChildProcess.exithandler (child_process.js:301:5)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Socket.stream.socket.on (internal/child_process.js:389:11)
    at Socket.emit (events.js:198:13)
    at Pipe._handle.close (net.js:606:12)
```

With error checking before, we'd get this error if we used `console.error(error)`:
```
{ error:
   { Error: Command failed: [ffmpeg command + stderr snipped]
   
       at ChildProcess.exithandler (child_process.js:294:12)
       at ChildProcess.emit (events.js:198:13)
       at maybeClose (internal/child_process.js:982:16)
       at Socket.stream.socket.on (internal/child_process.js:389:11)
       at Socket.emit (events.js:198:13)
       at Pipe._handle.close (net.js:606:12)
     killed: false,
     code: 1,
     signal: null,
     cmd: [ffmpeg command snipped] },
  stderr: [stderr snipped],
  stdout: '' }
```

Note that we have the command and stderr duplicated multiple times and that the stack does not include our code (harder to debug). Also, the rejected object is not an Error object.

With error checking now, error looks like:
```
{ FFmpegError: File '/path/to/slop.mp4' already exists. Overwrite ? [y/N] Not overwriting - exiting
    at cp.execFile (/path/to/fessonia/lib/ffmpeg_command.js:152:25)
    at ChildProcess.exithandler (child_process.js:301:5)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Socket.stream.socket.on (internal/child_process.js:389:11)
    at Socket.emit (events.js:198:13)
    at Pipe._handle.close (net.js:606:12)
  name: 'FFmpegError',
  code: 1,
  stderr: 'Command failed: [ffmpeg command + stderr snipped]',
  killed: false,
  signal: null,
  cmd: '[ffmpeg command snipped]' }
```

The custom FFmpegError object does the following things:
- uses the last line of stderr as the error message (last line usually contains the relevant error text)
- inserts our execFile into the stack for more trace-ability
- captures full stderr on `error.stderr`
- copies other properties from the child_process error (cmd, killed, signal, code)