### PR TITLE
Refactor filter node interface

### DIFF
--- a/docs/tutorials/1_example_overlay_images.md
+++ b/docs/tutorials/1_example_overlay_images.md
@@ -12,26 +12,24 @@ To construct this in JavaScript using the library, you can use the following.
 const fessonia = require('@tedconf/fessonia')();
 
 // Create command
-const cmd = new fessonia.FFmpegCommand({});
+const cmd = new fessonia.FFmpegCommand();
 
 // Add inputs
 ['input.mov', 'logo1.png', 'logo2.png']
   .forEach((ffin) => cmd.addInput(new fessonia.FFmpegInput(ffin)));
 
-// Generate filtergraph
-const overlay1 = new fessonia.FilterNode({
-  filterName: 'overlay',
+// Generate a filter chain and add it to the command's filter graph
+const overlay1 = new fessonia.FilterNode(
+  /* the ffmpeg filter name */
+  'overlay',
   /* args can be specified as named arguments */
-  args: [
-    {name: 'x', value: 10},
-    {name: 'y', value: 'main_h-overlay_h-10'}
-  ]
-});
-const overlay2 = new fessonia.FilterNode({
-  filterName: 'overlay',
+  { x: 10, y: 'main_h-overlay_h-10' }
+);
+const overlay2 = new fessonia.FilterNode(
+  'overlay',
   /* or args can be specified as ordered arguments */
-  args: ['main_w-overlay_w-10', 'main_h-overlay_h-10']
-});
+  ['main_w-overlay_w-10', 'main_h-overlay_h-10']
+);
 const filterchain = new fessonia.FilterChain([overlay1,overlay2]);
 cmd.addFilterChain(filterchain);
 

--- a/docs/tutorials/2_example_generate_test_video.md
+++ b/docs/tutorials/2_example_generate_test_video.md
@@ -17,22 +17,16 @@ To do the same using Fessonia in JavaScript, you would do the following.
 const { FilterNode, FilterChain, FFmpegInput, FFmpegOutput, FFmpegCommand } = require('@tedconf/fessonia')();
 
 // Construct the video filtergraph and corresponding input
-const lifeFilter = new FilterNode({
-  filterName: 'life',
-  args: [
-    { name: 'size', value: '320x240' },
-    { name: 'mold', value: 10 },
-    { name: 'rate', value: 23.976 },
-    { name: 'ratio', value: 0.5 },
-    { name: 'death_color', value: '#C83232' },
-    { name: 'life_color', value: '#00ff00' },
-    { name: 'stitch', value: 0 }
-  ]
+const lifeFilter = new FilterNode('life',{
+  size: '320x240',
+  mold: 10,
+  rate: 23.976,
+  ratio: 0.5,
+  death_color: '#C83232',
+  life_color: '#00ff00',
+  stitch: 0
 });
-const scaleFilter = new FilterNode({
-  filterName: 'scale',
-  args: [1920, 1080]
-});
+const scaleFilter = new FilterNode('scale', [1920, 1080]);
 const videoFilters = new FilterChain([lifeFilter, scaleFilter]);
 const videoIn = new FFmpegInput(videoFilters, new Map([
   ['r', 23.976],
@@ -40,14 +34,11 @@ const videoIn = new FFmpegInput(videoFilters, new Map([
 ]));
 
 // Construct the audio filtergraph and corresponding input
-const sineFilter = new FilterNode({
-  filterName: 'sine',
-  args: [
-    { name: 'frequency', value: 620 },
-    { name: 'beep_factor', value: 4 },
-    { name: 'duration', value: 999999 },
-    { name: 'sample_rate', value: 48000 }
-  ]
+const sineFilter = new FilterNode('sine', {
+  frequency: 620,
+  beep_factor: 4,
+  duration: 999999,
+  sample_rate: 48000,
 });
 const audioFilters = new FilterChain([sineFilter]);
 const audioIn = new FFmpegInput(audioFilters, new Map([

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -12,9 +12,11 @@ const logger = config.logger;
 class FilterNode {
   /**
    * Create a filter for use in an FFmpeg filter graph
-   * @param {Object} options - the options for the filter
+   * @param {string} filterName - the name of the filter
+   * @param {Array<any>} args - the arguments for the filter (default: {})
+   * @param {Object} options - options for the FilterNode object (default: {})
    */
-  constructor (options) {
+  constructor (filterName, args = [], options = {}) {
     this.ffmpegFilterInfo = undefined;
     this.filterIOType = undefined;
     this.inputType = undefined;
@@ -26,9 +28,9 @@ class FilterNode {
     if (!FilterNode._initialized) {
       FilterNode.initialize();
     }
-    this._configureFilter(options);
+    this._configureFilter(filterName, args, options);
 
-    this.padPrefix = `${this.options.filterName}_${this._digest(true).substring(0,12)}`;
+    this.padPrefix = `${filterName}_${this._digest(true).substring(0,12)}`;
     return this;
   }
 
@@ -46,7 +48,7 @@ class FilterNode {
    * @return {string} the filter argument string
    */
   toString () {
-    return (this.options.filterName + this._processFilterArguments(this.options.args));
+    return (this.filterName + this.argsString);
   }
 
   /**
@@ -111,21 +113,25 @@ class FilterNode {
 
   /**
    * Validate the options object used to create a filter node
-   * @param {Object} options - the options for the input
+   * @param {string} filterName - the filterName for the filter
+   * @param {Object} args - the arguments for the filter
+   * @param {Object} options - the options for the FilterNode object
    *
-   * @returns {Object} - returns options passed in if no error
+   * @returns {Object} - returns object with all arguments passed in if no error
    *
    * @private
    */
-  _validateOptions (options) {
-    if (!options.hasOwnProperty('filterName')) {
-      const errMsg = `FilterNode ${util.inspect(this)} options object does not specify a 'filterName' property. Please supply a value for options.filterName when creating the FilterNode.`;
+  _validateOptions (filterName, args, options) {
+    const validated = {};
+    if (!filterName) {
+      const errMsg = 'FilterNode constructor requires a filterName parameter. Please supply a value for filterName when creating the FilterNode.';
       throw new Error(errMsg);
     }
-    const info = FilterNode.ValidFilters[options.filterName];
+    const info = FilterNode.ValidFilters[filterName];
     if (!info) {
-      logger.warn(`FilterNode ${util.inspect(this)} options object specifies unknown value for 'filterName' property. Please ensure that your FFmpeg installation understands the filter name. You can see what filters FFmpeg knows about with: ffmpeg -filters`);
+      logger.warn('Unknown value for filterName parameter. Please ensure that your FFmpeg installation understands the filter name. You can see what filters FFmpeg knows about with: ffmpeg -filters');
     }
+    validated.filterName = filterName;
     if (info) {
       let pads;
       switch (info.inputPads) {
@@ -191,23 +197,31 @@ class FilterNode {
         }
       }
     }
-    if (options.hasOwnProperty('args')) {
-      this._processFilterArguments(options.args);
+    validated.options = options;
+    if (args) {
+      validated.argsString = this._processFilterArguments(args);
     }
-    return options;
+    validated.args = args;
+    return validated;
   }
 
   /**
    * Configure the filter node based on the options provided
-   * @param {Object} options - the options for the input
+   * @param {string} filterName - the name of the filter
+   * @param {Object} args - the args for the filter
+   * @param {Object} options - the options for the FilterNode object
    *
    * @returns {ThisType} - returns itself (this)
    *
    * @private
    */
-  _configureFilter (options) {
-    this.options = this._validateOptions(options);
-    const ffmpegFilter = FilterNode.ValidFilters[options.filterName];
+  _configureFilter (filterName, args, options) {
+    const validated = this._validateOptions(filterName, args, options);
+    this.filterName = validated.filterName;
+    this.args = validated.args;
+    this.argsString = validated.argsString;
+    this.options = validated.options;
+    const ffmpegFilter = FilterNode.ValidFilters[filterName];
     this.ffmpegFilterInfo = ffmpegFilter;
     this.filterIOType = FilterNode._getFilterIOType(ffmpegFilter);
     return this;
@@ -243,7 +257,8 @@ class FilterNode {
         throw new Error(`Invalid argument ${util.inspect(arg)} of FilterNode ${util.inspect(this)}. Filter arguments should be either a string or an object with keys 'name' and 'value', or in rare cases, an Array.`);
       }
     }
-    return('=' + (argterms.concat(kvargs).join(':')));
+    const argsString = argterms.concat(kvargs).join(':');
+    return(argsString.length > 0 ? '=' + argsString : '');
   }
 
   /**

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -238,23 +238,29 @@ class FilterNode {
   _processFilterArguments (args) {
     if (!args) { return (''); }
     let argterms = [], kvargs = [];
-    for (let arg of args) {
-      switch (typeof arg) {
-      case 'object':
-        if (arg.hasOwnProperty('name') && arg.hasOwnProperty('value')) {
-          kvargs.push(`${arg.name}=${FilterNode._handleArrayArguments(arg.value)}`);
-        } else if (Array.isArray(arg)) {
-          argterms.push(FilterNode._handleArrayArguments(arg));
-        } else {
+    if (Array.isArray(args)) {
+      for (let arg of args) {
+        switch (typeof arg) {
+        case 'object':
+          if (Array.isArray(arg)) {
+            argterms.push(FilterNode._handleArrayArguments(arg));
+          } else {
+            for (let key of Object.getOwnPropertyNames(arg)) {
+              kvargs.push(`${key}=${FilterNode._handleArrayArguments(arg[key])}`);
+            }
+          }
+          break;
+        case 'string':
+        case 'number':
+          argterms.push(arg);
+          break;
+        default:
           throw new Error(`Invalid argument ${util.inspect(arg)} of FilterNode ${util.inspect(this)}. Filter arguments should be either a string or an object with keys 'name' and 'value', or in rare cases, an Array.`);
         }
-        break;
-      case 'string':
-      case 'number':
-        argterms.push(arg);
-        break;
-      default:
-        throw new Error(`Invalid argument ${util.inspect(arg)} of FilterNode ${util.inspect(this)}. Filter arguments should be either a string or an object with keys 'name' and 'value', or in rare cases, an Array.`);
+      }
+    } else {
+      for (let key of Object.getOwnPropertyNames(args)) {
+        kvargs.push(`${key}=${FilterNode._handleArrayArguments(args[key])}`);
       }
     }
     const argsString = argterms.concat(kvargs).join(':');

--- a/test/example_commands.test.js
+++ b/test/example_commands.test.js
@@ -19,7 +19,7 @@ describe('FFmpegCommand', function () {
     });
   
     it('encodes example #1, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [320, 180] });
+      const scaleNode = new FilterNode('scale', [320, 180]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=320:180[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "baseline" -level:v "1.3" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "112k" -minrate "100.8k" -maxrate "123.2k" -bufsize "13.44k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -46,7 +46,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #1, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [320, 180] });
+      const scaleNode = new FilterNode('scale', [320, 180]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=320:180[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "baseline" -level:v "1.3" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "112k" -movflags "+faststart" -minrate "100.8k" -maxrate "123.2k" -bufsize "13.44k" -c:a "aac" -b:a "24k" -ar "24k" -ac "1" -f "mp4" -aspect "16:9" -pass "2" "/some/output_320x180_Low.mp4"`
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -77,7 +77,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #2, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [320, 180] });
+      const scaleNode = new FilterNode('scale', [320, 180]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=320:180[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "baseline" -level:v "3.0" -pix_fmt "yuv420p" -g "48" -b:v "180k" -minrate "162k" -maxrate "198k" -bufsize "36k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -103,7 +103,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #2, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [320, 180] });
+      const scaleNode = new FilterNode('scale', [320, 180]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=320:180[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "baseline" -level:v "3.0" -pix_fmt "yuv420p" -g "48" -b:v "180k" -movflags "+faststart" -minrate "162k" -maxrate "198k" -bufsize "36k" -c:a "libfdk_aac" -b:a "40k" -ar "44.1k" -ac "1" -f "mp4" -aspect "16:9" -pass "2" "/some/output_320x180_High.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -133,7 +133,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #3, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [416, 234] });
+      const scaleNode = new FilterNode('scale', [416, 234]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=416:234[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "baseline" -level:v "3.0" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "300k" -minrate "270k" -maxrate "330k" -bufsize "30k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -160,7 +160,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #3, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [416, 234] });
+      const scaleNode = new FilterNode('scale', [416, 234]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=416:234[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "baseline" -level:v "3.0" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "300k" -movflags "+faststart" -minrate "270k" -maxrate "330k" -bufsize "30k" -c:a "aac" -b:a "40k" -ar "44.1k" -ac "1" -f "mp4" -aspect "16:9" -pass "2" "/some/output_416x234_Low.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -191,7 +191,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #4, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [416, 234] });
+      const scaleNode = new FilterNode('scale', [416, 234]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=416:234[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "high" -level:v "3.0" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "427.5k" -minrate "384.75k" -maxrate "470.25k" -bufsize "64.125k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -218,7 +218,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #4, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [416, 234] });
+      const scaleNode = new FilterNode('scale', [416, 234]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=416:234[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "high" -level:v "3.0" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "427.5k" -movflags "+faststart" -minrate "384.75k" -maxrate "470.25k" -bufsize "64.125k" -c:a "libfdk_aac" -b:a "40k" -ar "44.1k" -ac "1" -f "mp4" -aspect "16:9" -pass "2" "/some/output_416x234_High.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -249,7 +249,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #5, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [480, 270] });
+      const scaleNode = new FilterNode('scale', [480, 270]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=480:270[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "600k" -minrate "540k" -maxrate "660k" -bufsize "60k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -275,7 +275,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #5, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [480, 270] });
+      const scaleNode = new FilterNode('scale', [480, 270]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=480:270[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "600k" -movflags "+faststart" -minrate "540k" -maxrate "660k" -bufsize "60k" -c:a "aac" -b:a "50k" -ar "44.1k" -ac "2" -f "mp4" -aspect "16:9" -pass "2" "/some/output_480x270.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -305,7 +305,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #6, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [640, 360] });
+      const scaleNode = new FilterNode('scale', [640, 360]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=640:360[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "high" -level:v "3.1" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "900k" -minrate "810k" -maxrate "990k" -bufsize "115k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -332,7 +332,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #6, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [640, 360] });
+      const scaleNode = new FilterNode('scale', [640, 360]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=640:360[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "fast" -profile:v "high" -level:v "3.1" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "900k" -movflags "+faststart" -minrate "810k" -maxrate "990k" -bufsize "115k" -c:a "libfdk_aac" -b:a "75k" -ar "44.1k" -ac "2" -f "mp4" -aspect "16:9" -pass "2" "/some/output_640x360.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -363,7 +363,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #7, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [854, 480] });
+      const scaleNode = new FilterNode('scale', [854, 480]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=854:480[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "1200k" -minrate "1080k" -maxrate "1320k" -bufsize "120k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -389,7 +389,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #7, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [854, 480] });
+      const scaleNode = new FilterNode('scale', [854, 480]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=854:480[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -level:v "3.1" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "1200k" -minrate "1080k" -maxrate "1320k" -bufsize "120k" -c:a "aac" -b:a "96k" -ar "44.1k" -ac "2" -f "mp4" -aspect "16:9" -pass "2" "/some/output_854x480.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -419,7 +419,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #8, pass 1', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [1280, 720] });
+      const scaleNode = new FilterNode('scale', [1280, 720]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=1280:720[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "3000k" -minrate "2700k" -maxrate "3300k" -bufsize "300k" -an -f "mp4" -aspect "16:9" -pass "1" "/dev/null"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});
@@ -445,7 +445,7 @@ describe('FFmpegCommand', function () {
       expect(fc.toString()).to.eql(expected);
     });
     it('encodes example #8, pass 2', function () {
-      const scaleNode = new FilterNode({ filterName: 'scale', args: [1280, 720] });
+      const scaleNode = new FilterNode('scale', [1280, 720]);
       const expected = `${config.ffmpeg_bin} -y -i "/some/input_master.mov" -filter_complex "scale=1280:720[${scaleNode.padPrefix}_0]" -c:v "libx264" -preset:v "slow" -profile:v "high" -pix_fmt "yuv420p" -coder "1" -g "48" -b:v "3000k" -movflags "+faststart" -minrate "2700k" -maxrate "3300k" -bufsize "300k" -c:a "aac" -b:a "96k" -ar "48k" -ac "2" -f "mp4" -aspect "16:9" -pass "2" "/some/output_1280x720_High.mp4"`;
       const fc = new FFmpegCommand({ y: null });
       const fi = new FFmpegInput('/some/input_master.mov', {});

--- a/test/ffmpeg_command.test.js
+++ b/test/ffmpeg_command.test.js
@@ -54,9 +54,7 @@ describe('FFmpegCommand', function () {
   describe('addFilterChain', function () {
     it('allows adding filter chains to the command filter graph', function () {
       const cmd = new FFmpegCommand();
-      const fc = new FilterChain([new FilterNode({
-        filterName: 'scale', args: [640,-1]
-      })]);
+      const fc = new FilterChain([new FilterNode('scale', [640,-1])]);
       cmd.addFilterChain(fc);
       expect(cmd.filterGraph.toString()).to.eql(fc.toString());
     });
@@ -156,23 +154,17 @@ describe('FFmpegCommand', function () {
   });
   it('generates the correct command string when IO mappings are present', function () {
     const cmd = new FFmpegCommand(new Map([['y'],]));
-    const scaleFilter = new FilterNode({
-      filterName: 'scale',
-      args: [1920, 1080]
-    });
+    const scaleFilter = new FilterNode('scale', [1920, 1080]);
     const nodes = [
-      new FilterNode({
-        filterName: 'life',
-        args: [
-          { name: 'size', value: '320x240' },
-          { name: 'mold', value: 10 },
-          { name: 'rate', value: 23.976 },
-          { name: 'ratio', value: 0.5 },
-          { name: 'death_color', value: '#C83232' },
-          { name: 'life_color', value: '#00ff00' },
-          { name: 'stitch', value: 0 }
-        ]
-      }),
+      new FilterNode('life', [
+        { name: 'size', value: '320x240' },
+        { name: 'mold', value: 10 },
+        { name: 'rate', value: 23.976 },
+        { name: 'ratio', value: 0.5 },
+        { name: 'death_color', value: '#C83232' },
+        { name: 'life_color', value: '#00ff00' },
+        { name: 'stitch', value: 0 }
+      ]),
       scaleFilter
     ];
     let scaledLife = new FilterChain(nodes);
@@ -181,15 +173,12 @@ describe('FFmpegCommand', function () {
       ['r', 23.976],
       ['f', 'lavfi']
     ]));
-    let sineFilter = new FilterNode({
-      filterName: 'sine',
-      args: [
-        { name: 'frequency', value: 620 },
-        { name: 'beep_factor', value: 4 },
-        { name: 'duration', value: 9999999999 },
-        { name: 'sample_rate', value: 48000 }
-      ]
-    });
+    let sineFilter = new FilterNode('sine', [
+      { name: 'frequency', value: 620 },
+      { name: 'beep_factor', value: 4 },
+      { name: 'duration', value: 9999999999 },
+      { name: 'sample_rate', value: 48000 }
+    ]);
     let sineInput = new FFmpegInput(sineFilter, new Map([
       ['re', null],
       ['r', 23.976],

--- a/test/ffmpeg_command.test.js
+++ b/test/ffmpeg_command.test.js
@@ -156,15 +156,15 @@ describe('FFmpegCommand', function () {
     const cmd = new FFmpegCommand(new Map([['y'],]));
     const scaleFilter = new FilterNode('scale', [1920, 1080]);
     const nodes = [
-      new FilterNode('life', [
-        { name: 'size', value: '320x240' },
-        { name: 'mold', value: 10 },
-        { name: 'rate', value: 23.976 },
-        { name: 'ratio', value: 0.5 },
-        { name: 'death_color', value: '#C83232' },
-        { name: 'life_color', value: '#00ff00' },
-        { name: 'stitch', value: 0 }
-      ]),
+      new FilterNode('life', {
+        size: '320x240',
+        mold: 10,
+        rate: 23.976,
+        ratio: 0.5,
+        death_color: '#C83232',
+        life_color: '#00ff00',
+        stitch: 0
+      }),
       scaleFilter
     ];
     let scaledLife = new FilterChain(nodes);
@@ -173,12 +173,12 @@ describe('FFmpegCommand', function () {
       ['r', 23.976],
       ['f', 'lavfi']
     ]));
-    let sineFilter = new FilterNode('sine', [
-      { name: 'frequency', value: 620 },
-      { name: 'beep_factor', value: 4 },
-      { name: 'duration', value: 9999999999 },
-      { name: 'sample_rate', value: 48000 }
-    ]);
+    let sineFilter = new FilterNode('sine', {
+      frequency: 620,
+      beep_factor: 4,
+      duration: 9999999999,
+      sample_rate: 48000
+    });
     let sineInput = new FFmpegInput(sineFilter, new Map([
       ['re', null],
       ['r', 23.976],

--- a/test/ffmpeg_input.test.js
+++ b/test/ffmpeg_input.test.js
@@ -88,23 +88,20 @@ describe('FFmpegInput', function () {
       // stub for ffmpeg interaction
       sinon.stub(FilterNode, '_queryFFmpegForFilters')
         .returns(filtersFixture);
-      cropFilter = new FilterNode({ filterName: 'crop', args: ['iw', 'ih/2', 0, 0] });
-      vflipFilter = new FilterNode({ filterName: 'vflip' });
-      splitFilter = new FilterNode({ filterName: 'split', outputsCount: 2 });
+      cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0]);
+      vflipFilter = new FilterNode('vflip');
+      splitFilter = new FilterNode('split', [], { outputsCount: 2 });
       nodes = [ cropFilter, vflipFilter, splitFilter ];
       fc = new FilterChain(nodes);
     });
 
     it('handles a single filter as input', function () {
-      let fInput = new FilterNode({
-        filterName: 'sine',
-        args: [
-          { name: 'frequency', value: 620 },
-          { name: 'beep_factor', value: 4 },
-          { name: 'duration', value: 9999999999 },
-          { name: 'sample_rate', value: 48000 }
-        ]
-      });
+      let fInput = new FilterNode('sine', [
+        { name: 'frequency', value: 620 },
+        { name: 'beep_factor', value: 4 },
+        { name: 'duration', value: 9999999999 },
+        { name: 'sample_rate', value: 48000 }
+      ]);
       let expected = `-re -f "lavfi" -i "sine=frequency=620:beep_factor=4:duration=9999999999:sample_rate=48000[${fInput.padPrefix}_0]"`;
       let fiObj = new FFmpegInput(fInput, new Map([
         ['re', null],
@@ -114,22 +111,16 @@ describe('FFmpegInput', function () {
     });
 
     it('handles a filter chain as input', function () {
-      const lifeNode = new FilterNode({
-        filterName: 'life',
-        args: [
-          { name: 'size', value: '320x240' },
-          { name: 'mold', value: 10 },
-          { name: 'rate', value: 23.976 },
-          { name: 'ratio', value: 0.5 },
-          { name: 'death_color', value: '#C83232' },
-          { name: 'life_color', value: '#00ff00' },
-          { name: 'stitch', value: 0 }
-        ]
-      });
-      const scaleNode = new FilterNode({
-        filterName: 'scale',
-        args: [1920, 1080]
-      });
+      const lifeNode = new FilterNode('life', [
+        { name: 'size', value: '320x240' },
+        { name: 'mold', value: 10 },
+        { name: 'rate', value: 23.976 },
+        { name: 'ratio', value: 0.5 },
+        { name: 'death_color', value: '#C83232' },
+        { name: 'life_color', value: '#00ff00' },
+        { name: 'stitch', value: 0 }
+      ]);
+      const scaleNode = new FilterNode('scale', [1920, 1080]);
       const expected = `-re -r "23.976" -f "lavfi" -i "life=size=320x240:mold=10:rate=23.976:ratio=0.5:death_color=#C83232:life_color=#00ff00:stitch=0,scale=1920:1080[${scaleNode.padPrefix}_0]"`;
       const fcInput = new FilterChain([lifeNode, scaleNode]);
       const fiObj = new FFmpegInput(fcInput, new Map([
@@ -141,22 +132,16 @@ describe('FFmpegInput', function () {
     });
 
     it('handles a filter graph as input', function () {
-      const lifeNode = new FilterNode({
-        filterName: 'life',
-        args: [
-          { name: 'size', value: '320x240' },
-          { name: 'mold', value: 10 },
-          { name: 'rate', value: 23.976 },
-          { name: 'ratio', value: 0.5 },
-          { name: 'death_color', value: '#C83232' },
-          { name: 'life_color', value: '#00ff00' },
-          { name: 'stitch', value: 0 }
-        ]
-      });
-      const scaleNode = new FilterNode({
-        filterName: 'scale',
-        args: [1920, 1080]
-      });
+      const lifeNode = new FilterNode('life', [
+        { name: 'size', value: '320x240' },
+        { name: 'mold', value: 10 },
+        { name: 'rate', value: 23.976 },
+        { name: 'ratio', value: 0.5 },
+        { name: 'death_color', value: '#C83232' },
+        { name: 'life_color', value: '#00ff00' },
+        { name: 'stitch', value: 0 }
+      ]);
+      const scaleNode = new FilterNode('scale', [1920, 1080]);
       const expected = `-re -r "23.976" -f "lavfi" -i "life=size=320x240:mold=10:rate=23.976:ratio=0.5:death_color=#C83232:life_color=#00ff00:stitch=0,scale=1920:1080[${scaleNode.padPrefix}_0]"`;
       const fc = new FilterChain([lifeNode, scaleNode]);
       const fgInput = new FilterGraph();

--- a/test/ffmpeg_input.test.js
+++ b/test/ffmpeg_input.test.js
@@ -96,12 +96,12 @@ describe('FFmpegInput', function () {
     });
 
     it('handles a single filter as input', function () {
-      let fInput = new FilterNode('sine', [
-        { name: 'frequency', value: 620 },
-        { name: 'beep_factor', value: 4 },
-        { name: 'duration', value: 9999999999 },
-        { name: 'sample_rate', value: 48000 }
-      ]);
+      let fInput = new FilterNode('sine', {
+        frequency: 620,
+        beep_factor: 4,
+        duration: 9999999999,
+        sample_rate: 48000
+      });
       let expected = `-re -f "lavfi" -i "sine=frequency=620:beep_factor=4:duration=9999999999:sample_rate=48000[${fInput.padPrefix}_0]"`;
       let fiObj = new FFmpegInput(fInput, new Map([
         ['re', null],
@@ -111,15 +111,15 @@ describe('FFmpegInput', function () {
     });
 
     it('handles a filter chain as input', function () {
-      const lifeNode = new FilterNode('life', [
-        { name: 'size', value: '320x240' },
-        { name: 'mold', value: 10 },
-        { name: 'rate', value: 23.976 },
-        { name: 'ratio', value: 0.5 },
-        { name: 'death_color', value: '#C83232' },
-        { name: 'life_color', value: '#00ff00' },
-        { name: 'stitch', value: 0 }
-      ]);
+      const lifeNode = new FilterNode('life', {
+        size: '320x240',
+        mold: 10,
+        rate: 23.976,
+        ratio: 0.5,
+        death_color: '#C83232',
+        life_color: '#00ff00',
+        stitch: 0
+      });
       const scaleNode = new FilterNode('scale', [1920, 1080]);
       const expected = `-re -r "23.976" -f "lavfi" -i "life=size=320x240:mold=10:rate=23.976:ratio=0.5:death_color=#C83232:life_color=#00ff00:stitch=0,scale=1920:1080[${scaleNode.padPrefix}_0]"`;
       const fcInput = new FilterChain([lifeNode, scaleNode]);
@@ -132,15 +132,15 @@ describe('FFmpegInput', function () {
     });
 
     it('handles a filter graph as input', function () {
-      const lifeNode = new FilterNode('life', [
-        { name: 'size', value: '320x240' },
-        { name: 'mold', value: 10 },
-        { name: 'rate', value: 23.976 },
-        { name: 'ratio', value: 0.5 },
-        { name: 'death_color', value: '#C83232' },
-        { name: 'life_color', value: '#00ff00' },
-        { name: 'stitch', value: 0 }
-      ]);
+      const lifeNode = new FilterNode('life', {
+        size: '320x240',
+        mold: 10,
+        rate: 23.976,
+        ratio: 0.5,
+        death_color: '#C83232',
+        life_color: '#00ff00',
+        stitch: 0
+      });
       const scaleNode = new FilterNode('scale', [1920, 1080]);
       const expected = `-re -r "23.976" -f "lavfi" -i "life=size=320x240:mold=10:rate=23.976:ratio=0.5:death_color=#C83232:life_color=#00ff00:stitch=0,scale=1920:1080[${scaleNode.padPrefix}_0]"`;
       const fc = new FilterChain([lifeNode, scaleNode]);

--- a/test/ffmpeg_option.test.js
+++ b/test/ffmpeg_option.test.js
@@ -55,12 +55,9 @@ describe('FFmpegOption', function () {
         sinon.stub(FilterNode, '_queryFFmpegForFilters')
           .returns(filtersFixture);
         nodes = [
-          new FilterNode({
-            filterName: 'crop',
-            args: ['iw', 'ih/2', 0, 0]
-          }),
-          new FilterNode({ filterName: 'vflip' }),
-          new FilterNode({ filterName: 'split', outputsCount: 2 })
+          new FilterNode('crop', ['iw', 'ih/2', 0, 0]),
+          new FilterNode('vflip'),
+          new FilterNode('split', [], { outputsCount: 2 })
         ];
         fc = new FilterChain(nodes);
         fg = new FilterGraph();
@@ -127,20 +124,10 @@ describe('FFmpegOption', function () {
         // stub for ffmpeg interaction
         sinon.stub(FilterNode, '_queryFFmpegForFilters')
           .returns(filtersFixture);
-        cropFilter = new FilterNode({
-          filterName: 'crop',
-          args: ['iw', 'ih/2', 0, 0]
-        })
-        splitFilter = new FilterNode({
-          filterName: 'split',
-          outputsCount: 2
-        })
-        vflipFilter1 = new FilterNode({
-          filterName: 'vflip'
-        })
-        vflipFilter2 = new FilterNode({
-          filterName: 'vflip'
-        })
+        cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0])
+        splitFilter = new FilterNode('split', [], { outputsCount: 2 })
+        vflipFilter1 = new FilterNode('vflip')
+        vflipFilter2 = new FilterNode('vflip')
         const fc1 = new FilterChain([
           cropFilter,
           splitFilter
@@ -215,20 +202,10 @@ describe('FFmpegOption', function () {
       this.beforeEach(() => {
         // stub for ffmpeg interaction
         sinon.stub(FilterNode, '_queryFFmpegForFilters').returns(filtersFixture);
-        cropFilter = new FilterNode({
-          filterName: 'crop',
-          args: ['iw', 'ih/2', 0, 0]
-        })
-        splitFilter = new FilterNode({
-          filterName: 'split',
-          outputsCount: 2
-        })
-        vflipFilter1 = new FilterNode({
-          filterName: 'vflip'
-        })
-        vflipFilter2 = new FilterNode({
-          filterName: 'vflip'
-        })
+        cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0])
+        splitFilter = new FilterNode('split', [], { outputsCount: 2 })
+        vflipFilter1 = new FilterNode('vflip')
+        vflipFilter2 = new FilterNode('vflip')
         const fc1 = new FilterChain([
           cropFilter,
           splitFilter

--- a/test/ffmpeg_output.test.js
+++ b/test/ffmpeg_output.test.js
@@ -86,13 +86,10 @@ describe('FFmpegOutput', function () {
       // stub for ffmpeg interaction
       sinon.stub(FilterNode, '_queryFFmpegForFilters')
         .returns(filtersFixture);
-      cropFilter = new FilterNode({
-        filterName: 'crop',
-        args: ['iw', 'ih/2', 0, 0]
-      });
-      vflipFilter = new FilterNode({ filterName: 'vflip' });
-      hflipFilter = new FilterNode({ filterName: 'hflip' });
-      splitFilter = new FilterNode({ filterName: 'split', outputsCount: 2 });
+      cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0]);
+      vflipFilter = new FilterNode('vflip');
+      hflipFilter = new FilterNode('hflip');
+      splitFilter = new FilterNode('split', [], { outputsCount: 2 });
       fc1 = new FilterChain([cropFilter, splitFilter])
       fc2 = new FilterChain([vflipFilter])
       fc2.addInput(fc1.streamSpecifier(0))
@@ -142,16 +139,10 @@ describe('FFmpegOutput', function () {
     it('allows adding a filter option after creation of the output object', function () {
       sinon.stub(FilterNode, '_queryFFmpegForFilters')
         .returns(filtersFixture);
-      const cropFilter = new FilterNode({
-        filterName: 'crop',
-        args: ['iw', 'ih/2', 0, 0]
-      });
-      const vflipFilter = new FilterNode({ filterName: 'vflip' });
-      const hflipFilter = new FilterNode({ filterName: 'hflip' });
-      const splitFilter = new FilterNode({
-        filterName: 'split',
-        outputsCount: 2
-      });
+      const cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0]);
+      const vflipFilter = new FilterNode('vflip');
+      const hflipFilter = new FilterNode('hflip');
+      const splitFilter = new FilterNode('split', [], { outputsCount: 2 });
       const nodes = [cropFilter, vflipFilter, hflipFilter, splitFilter];
       const connections = [
         [[cropFilter, '0'], [splitFilter, '0']],
@@ -193,10 +184,7 @@ describe('FFmpegOutput', function () {
     });
     it('adds filterChain streams to the output', () => {
       const fo = new FFmpegOutput('/some/file.mp4');
-      const node = new FilterNode({
-        filterName: 'scale',
-        args: [640, -1]
-      });
+      const node = new FilterNode('scale', [640, -1]);
       const fc = new FilterChain([node]);
       const videoStream = fc.streamSpecifier(0);
       fo.addStreams([ videoStream ]);
@@ -230,13 +218,8 @@ describe('FFmpegOutput', function () {
     });
     it('adds filterChain streams to the output in order', () => {
       const fo = new FFmpegOutput('/some/file.mp4');
-      const node1 = new FilterNode({
-        filterName: 'scale',
-        args: [640, -1]
-      });
-      const node2 = new FilterNode({
-        filterName: 'vflip'
-      })
+      const node1 = new FilterNode('scale', [640, -1]);
+      const node2 = new FilterNode('vflip');
       const fc1 = new FilterChain([node1]);
       const fc2 = new FilterChain([node2]);
       const stream1 = fc1.streamSpecifier(0);

--- a/test/ffmpeg_stream_specifier.test.js
+++ b/test/ffmpeg_stream_specifier.test.js
@@ -13,9 +13,9 @@ describe('FFmpegStreamSpecifier', () => {
   beforeEach(() => {
     // stub for ffmpeg interaction
     sinon.stub(FilterNode, '_queryFFmpegForFilters').returns(filtersFixture);
-    cropFilter = new FilterNode({ filterName: 'crop', args: ['iw', 'ih/2', 0, 0] });
-    vflipFilter = new FilterNode({ filterName: 'vflip' });
-    splitFilter = new FilterNode({ filterName: 'split', outputsCount: 2 });
+    cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0]);
+    vflipFilter = new FilterNode('vflip');
+    splitFilter = new FilterNode('split', [], { outputsCount: 2 });
     filterChain = new FilterChain([cropFilter, vflipFilter, splitFilter])
     ffmpegInput = new FFmpegInput('/some/uri')
   });

--- a/test/filter_chain.test.js
+++ b/test/filter_chain.test.js
@@ -13,9 +13,9 @@ describe('FilterChain', () => {
   beforeEach(() => {
     // stub for ffmpeg interaction
     sinon.stub(FilterNode, '_queryFFmpegForFilters').returns(filtersFixture);
-    cropFilter = new FilterNode({ filterName: 'crop', args: ['iw', 'ih/2', 0, 0] });
-    vflipFilter = new FilterNode({ filterName: 'vflip' });
-    splitFilter = new FilterNode({ filterName: 'split', outputsCount: 2 });
+    cropFilter = new FilterNode('crop', ['iw', 'ih/2', 0, 0]);
+    vflipFilter = new FilterNode('vflip');
+    splitFilter = new FilterNode('split', [], { outputsCount: 2 });
     nodes = [cropFilter, vflipFilter, splitFilter];
     ffmpegInput = new FFmpegInput('/some/uri');
   });
@@ -90,37 +90,28 @@ describe('FilterChain', () => {
 
   describe('example filter graphs from real use', function () {
     it('generative video filter to be used as an input', function () {
-      let lifeFilter = new FilterNode({
-        filterName: 'life',
-        args: [
-          { name: 'size', value: '320x240' },
-          { name: 'mold', value: 10 },
-          { name: 'rate', value: 23.976 },
-          { name: 'ratio', value: 0.5 },
-          { name: 'death_color', value: '#C83232' },
-          { name: 'life_color', value: '#00ff00' },
-          { name: 'stitch', value: 0 }
-        ]
-      });
-      let scaleFilter = new FilterNode({
-        filterName: 'scale',
-        args: [1920, 1080]
-      });
+      let lifeFilter = new FilterNode('life', [
+        { name: 'size', value: '320x240' },
+        { name: 'mold', value: 10 },
+        { name: 'rate', value: 23.976 },
+        { name: 'ratio', value: 0.5 },
+        { name: 'death_color', value: '#C83232' },
+        { name: 'life_color', value: '#00ff00' },
+        { name: 'stitch', value: 0 }
+      ]);
+      let scaleFilter = new FilterNode('scale', [1920, 1080]);
       let nodes = [lifeFilter, scaleFilter];
       let fc = new FilterChain(nodes);
       let expected = `life=size=320x240:mold=10:rate=23.976:ratio=0.5:death_color=#C83232:life_color=#00ff00:stitch=0,scale=1920:1080[${scaleFilter.padPrefix}_0]`;
       expect(fc.toString()).to.eql(expected);
     });
     it('generative audio filter to be used as input', function () {
-      let sineFilter = new FilterNode({
-        filterName: 'sine',
-        args: [
-          { name: 'frequency', value: 620 },
-          { name: 'beep_factor', value: 4 },
-          { name: 'duration', value: 9999999999 },
-          { name: 'sample_rate', value: 48000 }
-        ]
-      });
+      let sineFilter = new FilterNode('sine', [
+        { name: 'frequency', value: 620 },
+        { name: 'beep_factor', value: 4 },
+        { name: 'duration', value: 9999999999 },
+        { name: 'sample_rate', value: 48000 }
+      ]);
       let expected = `sine=frequency=620:beep_factor=4:duration=9999999999:sample_rate=48000[${sineFilter.padPrefix}_0]`;
       let fc = new FilterChain([sineFilter]);
       expect(fc.toString()).to.eql(expected);

--- a/test/filter_chain.test.js
+++ b/test/filter_chain.test.js
@@ -90,15 +90,15 @@ describe('FilterChain', () => {
 
   describe('example filter graphs from real use', function () {
     it('generative video filter to be used as an input', function () {
-      let lifeFilter = new FilterNode('life', [
-        { name: 'size', value: '320x240' },
-        { name: 'mold', value: 10 },
-        { name: 'rate', value: 23.976 },
-        { name: 'ratio', value: 0.5 },
-        { name: 'death_color', value: '#C83232' },
-        { name: 'life_color', value: '#00ff00' },
-        { name: 'stitch', value: 0 }
-      ]);
+      let lifeFilter = new FilterNode('life', {
+        size: '320x240',
+        mold: 10,
+        rate: 23.976,
+        ratio: 0.5,
+        death_color: '#C83232',
+        life_color: '#00ff00',
+        stitch: 0
+      });
       let scaleFilter = new FilterNode('scale', [1920, 1080]);
       let nodes = [lifeFilter, scaleFilter];
       let fc = new FilterChain(nodes);
@@ -106,12 +106,12 @@ describe('FilterChain', () => {
       expect(fc.toString()).to.eql(expected);
     });
     it('generative audio filter to be used as input', function () {
-      let sineFilter = new FilterNode('sine', [
-        { name: 'frequency', value: 620 },
-        { name: 'beep_factor', value: 4 },
-        { name: 'duration', value: 9999999999 },
-        { name: 'sample_rate', value: 48000 }
-      ]);
+      let sineFilter = new FilterNode('sine', {
+        frequency: 620,
+        beep_factor: 4,
+        duration: 9999999999,
+        sample_rate: 48000
+      });
       let expected = `sine=frequency=620:beep_factor=4:duration=9999999999:sample_rate=48000[${sineFilter.padPrefix}_0]`;
       let fc = new FilterChain([sineFilter]);
       expect(fc.toString()).to.eql(expected);

--- a/test/filter_graph.test.js
+++ b/test/filter_graph.test.js
@@ -14,31 +14,19 @@ describe('FilterGraph', function () {
     // stub for ffmpeg interaction
     sinon.stub(FilterNode, '_queryFFmpegForFilters')
       .returns(filtersFixture);
-    scaleFilter = new FilterNode({
-      filterName: 'scale',
-      args: [640, -1]
-    })
-    subtitlesFilter = new FilterNode({
-      filterName: 'subtitles',
-      args: [{
-        name: 'filename',
-        value: 'subtitles.srt'
-      }]
-    })
-    alimiterFilter = new FilterNode({
-      filterName: 'alimiter',
-      args: [{
-        name: 'limit',
-        value: 0.8
-      }]
-    })
-    denoiserFilter = new FilterNode({
-      filterName: 'atadenoise',
-      args: [{
-        name: 's',
-        value: 31
-      }]
-    })
+    scaleFilter = new FilterNode('scale', [640, -1])
+    subtitlesFilter = new FilterNode('subtitles', [{
+      name: 'filename',
+      value: 'subtitles.srt'
+    }])
+    alimiterFilter = new FilterNode('alimiter', [{
+      name: 'limit',
+      value: 0.8
+    }])
+    denoiserFilter = new FilterNode('atadenoise', [{
+      name: 's',
+      value: 31
+    }])
     video = new FFmpegInput(
       '/sources/2018S-RES0601-S02-DMX.mov',
       { 'ss': 5110.77 }

--- a/test/filter_graph.test.js
+++ b/test/filter_graph.test.js
@@ -15,18 +15,11 @@ describe('FilterGraph', function () {
     sinon.stub(FilterNode, '_queryFFmpegForFilters')
       .returns(filtersFixture);
     scaleFilter = new FilterNode('scale', [640, -1])
-    subtitlesFilter = new FilterNode('subtitles', [{
-      name: 'filename',
-      value: 'subtitles.srt'
-    }])
-    alimiterFilter = new FilterNode('alimiter', [{
-      name: 'limit',
-      value: 0.8
-    }])
-    denoiserFilter = new FilterNode('atadenoise', [{
-      name: 's',
-      value: 31
-    }])
+    subtitlesFilter = new FilterNode('subtitles', {
+      filename: 'subtitles.srt'
+    })
+    alimiterFilter = new FilterNode('alimiter', { limit: 0.8 })
+    denoiserFilter = new FilterNode('atadenoise', { s: 31 })
     video = new FFmpegInput(
       '/sources/2018S-RES0601-S02-DMX.mov',
       { 'ss': 5110.77 }

--- a/test/filter_node.test.js
+++ b/test/filter_node.test.js
@@ -47,12 +47,12 @@ describe('FilterNode', function () {
       // keyword args
       keywordArgsFilter = {
         filterName: 'crop',
-        args: [
-          { name: 'w', value: 100 },
-          { name: 'h', value: 100 },
-          { name: 'x', value: 12 },
-          { name: 'y', value: 34 }
-        ],
+        args: {
+          w: 100,
+          h: 100,
+          x: 12,
+          y: 34
+        },
         options: undefined,
         expectation: {
           toStringResult: 'crop=w=100:h=100:x=12:y=34'
@@ -61,7 +61,7 @@ describe('FilterNode', function () {
       // mixed args (this is horrible - don't do this - but we test anyway)
       mixedArgsFilter = {
         filterName: 'crop',
-        args: [ { name: 'x', value: 12 }, { name: 'y', value: 34 }, 100, 100 ],
+        args: [{ x: 12, y: 34 }, 100, 100 ],
         options: undefined,
         inputs: [{ alias: 'tmp'}],
         outputs: [{ alias: 'cropped'}],
@@ -145,21 +145,11 @@ describe('FilterNode', function () {
       // invalid arguments syntax
       badFilterDef4 = {
         filterName: 'crop',
-        args: [
-          { title: 'x', val: 12 },
-          { title: 'y', val: 34 },
-          { title: 'w', val: 100 },
-          { title: 'h', val: 100 }
-        ],
-        options: undefined
-      };
-      badFilterDef5 = {
-        filterName: 'crop',
         args: [ undefined, 3, null ],
         options: undefined
       };
       // unrecognized filterName
-      badFilterDef6 = {
+      badFilterDef5 = {
         filterName: 'asldfa3tgj23dghsdg',
         args: [],
         options: {}
@@ -197,14 +187,13 @@ describe('FilterNode', function () {
       expect(() => new FilterNode(badFilterDef2.filterName, badFilterDef2.args, badFilterDef2.options)).to.throw();
       expect(() => new FilterNode(badFilterDef3.filterName, badFilterDef3.args, badFilterDef3.options)).to.throw();
       expect(() => new FilterNode(badFilterDef4.filterName, badFilterDef4.args, badFilterDef4.options)).to.throw();
-      expect(() => new FilterNode(badFilterDef5.filterName, badFilterDef5.args, badFilterDef5.options)).to.throw();
 
       /*
       // TODO: Figure out how to stub this properly.
       const stubbedLogger = require('../lib/util/logger')('FilterNode(stubbed-logger)');
       stubbedLogger.warn = sinon.spy();
       sinon.stub(FilterNode, 'logger').returns(stubbedLogger);
-      new FilterNode(badFilterDef6.filterName, badFilterDef6.args, badFilterDef6.options);
+      new FilterNode(badFilterDef5.filterName, badFilterDef5.args, badFilterDef5.options);
       expect(stubbedLogger.warn.calledOnce()).to.be.true();
       */
     });

--- a/test/filter_node.test.js
+++ b/test/filter_node.test.js
@@ -17,10 +17,9 @@ describe('FilterNode', function () {
     this.beforeAll(() => {
       // basic test filter
       testFilter = {
-        options: {
-          filterName: 'crop',
-          args: ['iw', 'ih/2', 0, 0]
-        },
+        filterName: 'crop',
+        args: ['iw', 'ih/2', 0, 0],
+        options: undefined,
         expectation: {
           toStringResult: 'crop=iw:ih/2:0:0',
           filterIOType: FilterNode.FilterIOTypes.GENERIC
@@ -28,7 +27,9 @@ describe('FilterNode', function () {
       };
       // vflip filter
       otherTestFilter = {
-        options: { filterName: 'vflip' },
+        filterName: 'vflip',
+        args: undefined,
+        options: undefined,
         expectation: {
           toStringResult: 'vflip',
           filterIOType: FilterNode.FilterIOTypes.GENERIC
@@ -36,45 +37,44 @@ describe('FilterNode', function () {
       };
       // array args
       arrayArgsFilter = {
-        options: {
-          filterName: 'aecho',
-          args: [0.8, 0.9, [1000, 1800], [0.3, 0.25]]
-        },
+        filterName: 'aecho',
+        args: [0.8, 0.9, [1000, 1800], [0.3, 0.25]],
+        options: undefined,
         expectation: {
           toStringResult: 'aecho=0.8:0.9:1000|1800:0.3|0.25'
         }
       };
       // keyword args
       keywordArgsFilter = {
-        options: {
-          filterName: 'crop',
-          args: [
-            { name: 'w', value: 100 },
-            { name: 'h', value: 100 },
-            { name: 'x', value: 12 },
-            { name: 'y', value: 34 }
-          ]
-        },
+        filterName: 'crop',
+        args: [
+          { name: 'w', value: 100 },
+          { name: 'h', value: 100 },
+          { name: 'x', value: 12 },
+          { name: 'y', value: 34 }
+        ],
+        options: undefined,
         expectation: {
           toStringResult: 'crop=w=100:h=100:x=12:y=34'
         }
       };
       // mixed args (this is horrible - don't do this - but we test anyway)
       mixedArgsFilter = {
-        options: {
-          filterName: 'crop',
-          inputs: [{ alias: 'tmp'}],
-          outputs: [{ alias: 'cropped'}],
-          args: [ { name: 'x', value: 12 }, { name: 'y', value: 34 }, 100, 100 ]
-        },
+        filterName: 'crop',
+        args: [ { name: 'x', value: 12 }, { name: 'y', value: 34 }, 100, 100 ],
+        options: undefined,
+        inputs: [{ alias: 'tmp'}],
+        outputs: [{ alias: 'cropped'}],
         expectation: {
           toStringResult: 'crop=100:100:x=12:y=34'
         }
       };
       // filter command: COMPLEX
       complexFilter = {
+        filterName: 'split',
+        args: undefined,
         options: {
-          filterName: 'split'
+          outputsCount: 2
         },
         expectation: {
           filterIOType: FilterNode.FilterIOTypes.GENERIC
@@ -82,26 +82,27 @@ describe('FilterNode', function () {
       };
       // filter type: SOURCE
       sourceFilter = {
-        options: {
-          filterName: 'sine'
-        },
+        filterName: 'sine',
+        args: undefined,
+        options: undefined,
         expectation: {
           filterIOType: FilterNode.FilterIOTypes.SOURCE
         }
       };
       // filter type: SINK
       sinkFilter = {
-        options: {
-          filterName: 'nullsink'
-        },
+        filterName: 'nullsink',
+        args: undefined,
+        options: undefined,
         expectation: {
           filterIOType: FilterNode.FilterIOTypes.SINK
         }
       };
       // variable input filter
       varInputFilter = {
+        filterName: 'amerge',
+        args: undefined,
         options: {
-          filterName: 'amerge',
           inputsCount: 5
         },
         expectation: {
@@ -110,8 +111,9 @@ describe('FilterNode', function () {
       };
       // variable input filter
       varOutputFilter = {
+        filterName: 'asplit',
+        args: undefined,
         options: {
-          filterName: 'asplit',
           outputsCount: 4
         },
         expectation: {
@@ -120,43 +122,47 @@ describe('FilterNode', function () {
       };
       // no filterName
       badFilterDef1 = {
+        filterName: undefined,
+        args: [],
         options: {}
       };
       // invalid inputsCount
       badFilterDef2 = {
+        filterName: 'sine',
+        args: undefined,
         options: {
-          filterName: 'sine',
           inputsCount: 2
         }
       };
       // invalid outputsCount
       badFilterDef3 = {
+        filterName: 'nullsink',
+        args: undefined,
         options: {
-          filterName: 'nullsink',
           outputsCount: 1
         }
       };
       // invalid arguments syntax
       badFilterDef4 = {
-        options: {
-          filterName: 'crop',
-          args: [
-            { title: 'x', val: 12 },
-            { title: 'y', val: 34 },
-            { title: 'w', val: 100 },
-            { title: 'h', val: 100 }
-          ]
-        }
+        filterName: 'crop',
+        args: [
+          { title: 'x', val: 12 },
+          { title: 'y', val: 34 },
+          { title: 'w', val: 100 },
+          { title: 'h', val: 100 }
+        ],
+        options: undefined
       };
       badFilterDef5 = {
-        options: {
-          filterName: 'crop',
-          args: [ undefined, 3, null ]
-        }
+        filterName: 'crop',
+        args: [ undefined, 3, null ],
+        options: undefined
       };
       // unrecognized filterName
       badFilterDef6 = {
-        options: { filterName: 'asldfa3tgj23dghsdg' }
+        filterName: 'asldfa3tgj23dghsdg',
+        args: [],
+        options: {}
       };
     });
 
@@ -174,66 +180,74 @@ describe('FilterNode', function () {
       sinon.restore();
     });
 
+    it('sets the filter name', function () {
+      let f = new FilterNode(testFilter.filterName, testFilter.args, testFilter.options);
+      expect(f.filterName).to.deep.eql(testFilter.filterName);
+    });
+    it('sets the filter args', function () {
+      let f = new FilterNode(testFilter.filterName, testFilter.args, testFilter.options);
+      expect(f.args).to.deep.eql(testFilter.args);
+    });
     it('sets the filter options', function () {
-      let f = new FilterNode(testFilter.options);
-      expect(f.options).to.deep.eql(testFilter.options);
+      let f = new FilterNode(testFilter.filterName, testFilter.args, testFilter.options);
+      expect(f.options).to.deep.eql({});
     });
     it('validates the options object', function () {
-      expect(() => new FilterNode(badFilterDef1.options)).to.throw();
-      expect(() => new FilterNode(badFilterDef2.options)).to.throw();
-      expect(() => new FilterNode(badFilterDef3.options)).to.throw();
-      expect(() => new FilterNode(badFilterDef4.options)).to.throw();
-      expect(() => new FilterNode(badFilterDef5.options)).to.throw();
+      expect(() => new FilterNode(badFilterDef1.filterName, badFilterDef1.args, badFilterDef1.options)).to.throw();
+      expect(() => new FilterNode(badFilterDef2.filterName, badFilterDef2.args, badFilterDef2.options)).to.throw();
+      expect(() => new FilterNode(badFilterDef3.filterName, badFilterDef3.args, badFilterDef3.options)).to.throw();
+      expect(() => new FilterNode(badFilterDef4.filterName, badFilterDef4.args, badFilterDef4.options)).to.throw();
+      expect(() => new FilterNode(badFilterDef5.filterName, badFilterDef5.args, badFilterDef5.options)).to.throw();
 
       /*
       // TODO: Figure out how to stub this properly.
       const stubbedLogger = require('../lib/util/logger')('FilterNode(stubbed-logger)');
       stubbedLogger.warn = sinon.spy();
       sinon.stub(FilterNode, 'logger').returns(stubbedLogger);
-      new FilterNode(badFilterDef6.options);
+      new FilterNode(badFilterDef6.filterName, badFilterDef6.args, badFilterDef6.options);
       expect(stubbedLogger.warn.calledOnce()).to.be.true();
       */
     });
     it('sets the appropriate filter type', function () {
-      let f1 = new FilterNode(sourceFilter.options);
+      let f1 = new FilterNode(sourceFilter.filterName, sourceFilter.args, sourceFilter.options);
       expect(f1.filterIOType).to.eql(sourceFilter.expectation.filterIOType);
-      let f2 = new FilterNode(sinkFilter.options);
+      let f2 = new FilterNode(sinkFilter.filterName, sinkFilter.args, sinkFilter.options);
       expect(f2.filterIOType).to.eql(sinkFilter.expectation.filterIOType);
     });
     it('creates a unique pad prefix', function () {
-      let f1 = new FilterNode(testFilter.options);
+      let f1 = new FilterNode(testFilter.filterName, testFilter.args, testFilter.options);
       expect(f1.padPrefix).to.be.a('string');
-      let f2 = new FilterNode(otherTestFilter.options);
+      let f2 = new FilterNode(otherTestFilter.filterName, otherTestFilter.args, otherTestFilter.options);
       expect(f2.padPrefix).to.be.a('string');
     });
     it('handles inputs on variable-input filters', function () {
-      let f1 = new FilterNode(varInputFilter.options);
+      let f1 = new FilterNode(varInputFilter.filterName, varInputFilter.args, varInputFilter.options);
       expect(f1.inputs).to.deep.eql(varInputFilter.expectation.inputs);
     });
     it('handles outputs on variable-output filters', function () {
-      let f1 = new FilterNode(varOutputFilter.options);
+      let f1 = new FilterNode(varOutputFilter.filterName, varOutputFilter.args, varOutputFilter.options);
       expect(f1.outputs).to.deep.eql(varOutputFilter.expectation.outputs);
     });
     // array-only arguments
     it('generates the correct arguments string representation for array-only arguments', function () {
-      let f1 = new FilterNode(testFilter.options);
+      let f1 = new FilterNode(testFilter.filterName, testFilter.args, testFilter.options);
       expect(f1.toString()).to.eql(testFilter.expectation.toStringResult);
-      let f2 = new FilterNode(otherTestFilter.options);
+      let f2 = new FilterNode(otherTestFilter.filterName, otherTestFilter.args, otherTestFilter.options);
       expect(f2.toString()).to.eql(otherTestFilter.expectation.toStringResult);
     });
     // array-valued arguments
     it('generates the correct arguments string representation for array-valued arguments', function () {
-      let f = new FilterNode(arrayArgsFilter.options);
+      let f = new FilterNode(arrayArgsFilter.filterName, arrayArgsFilter.args, arrayArgsFilter.options);
       expect(f.toString()).to.deep.eql(arrayArgsFilter.expectation.toStringResult);
     });
     // keyword arguments
     it('generates the correct arguments string representation for keyword arguments', function () {
-      let f = new FilterNode(keywordArgsFilter.options);
+      let f = new FilterNode(keywordArgsFilter.filterName, keywordArgsFilter.args, keywordArgsFilter.options);
       expect(f.toString()).to.deep.eql(keywordArgsFilter.expectation.toStringResult);
     });
     // mixed arguments
     it('generates the correct arguments string representation for mixed arguments', function () {
-      let f = new FilterNode(mixedArgsFilter.options);
+      let f = new FilterNode(mixedArgsFilter.filterName, mixedArgsFilter.args, mixedArgsFilter.options);
       expect(f.toString()).to.deep.eql(mixedArgsFilter.expectation.toStringResult);
     });
     it('provides filter validation info based on ffmpeg help output', function () {


### PR DESCRIPTION
Changes the `FilterNode` constructor signature to:

```javascript
new FilterNode( filterName : string, args : Array|Object = [], options : Object = {} )
```

It also alters the `args` syntax for `FilterNode` to accept the following:

```javascript
[ arg1, arg2, ... ]
[ arg1, { arg2: val2, arg3: val3, ... }, arg5, ... ]
{ arg1: val1, arg2: val2, ... }
```
As per [FFmpeg Documentation](http://ffmpeg.org/ffmpeg-filters.html#Filtergraph-syntax-1), mixed arguments (like the second above) are handled with direct value arguments first, then key-value arguments.

This essentially simplifies the need for multiple `{ name: 'argname', value: argvalue }` object arguments, and collapses that to a single object of `key: value` arguments.

Documentation update also needed.