### PR TITLE
Expose FilterGraph and allow composing FilterGraphs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const getFessonia = (opts = {}) => {
     FFmpegInput: require('./lib/ffmpeg_input'),
     FFmpegOutput: require('./lib/ffmpeg_output'),
     FilterNode: require('./lib/filter_node'),
-    FilterChain: require('./lib/filter_chain')
+    FilterChain: require('./lib/filter_chain'),
+    FilterGraph: require('./lib/filter_graph')
   };
   return Fessonia;
 }

--- a/lib/ffmpeg_command.js
+++ b/lib/ffmpeg_command.js
@@ -72,7 +72,7 @@ class FFmpegCommand extends EventEmitter {
 
   /**
    * Add a filter chain to the FFmpegCommand object's filter graph
-   * @param {FilterGraph} filterChain - filter chain object
+   * @param {FilterChain} filterChain - filter chain object
    * @returns {void}
    */
   addFilterChain (filterChain) {
@@ -81,6 +81,19 @@ class FFmpegCommand extends EventEmitter {
       this._filterGraph = new FilterGraph();
     }
     this._filterGraph.addFilterChain(filterChain);
+  }
+
+  /**
+   * Add a filter graph to the FFmpegCommand object's filter graph
+   * @param {FilterGraph} filterGraph - filter graph object
+   * @returns {void}
+   */
+  addFilterGraph (filterGraph) {
+    if (typeof this._filterGraph === 'undefined') {
+      const FilterGraph = FFmpegCommand._loadFilterGraph();
+      this._filterGraph = new FilterGraph();
+    }
+    this._filterGraph.addFilterGraph(filterGraph);
   }
 
   /**

--- a/lib/filter_graph.js
+++ b/lib/filter_graph.js
@@ -30,6 +30,19 @@ class FilterGraph {
   }
 
   /**
+   * Adds a filter graph to the filter graph
+   * @param {FilterGraph} graph - the filter graph to be added
+   * @returns {void}
+   * @throws {Error}
+   */
+  addFilterGraph (graph) {
+    if (!(graph instanceof FilterGraph)) {
+      throw new Error('Invalid parameter chain: must be instance of FilterChain');
+    }
+    this.chains = this.chains.concat(graph.chains);
+  }
+
+  /**
    * Returns a string representation of the filter graph
    * @returns {string} the filter graph's string representation
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,6 +581,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
       "requires": {
         "check-error": "^1.0.2"
       }
@@ -605,7 +606,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "cheerio": {
       "version": "0.22.0",

--- a/test/filter_graph.test.js
+++ b/test/filter_graph.test.js
@@ -46,7 +46,7 @@ describe('FilterGraph', function () {
   })
   describe('addFilterChain()', () => {
     it('allows adding filter chains', () => {
-      const fg = new FilterGraph();
+      const fg = new FilterGraph()
       expect(fg.chains).to.be.instanceof(Array);
       expect(fg.chains.length).to.eql(0)
       fg.addFilterChain(videoFilters)
@@ -56,7 +56,17 @@ describe('FilterGraph', function () {
       expect(fg.chains.length).to.eql(2)
       expect(fg.chains[1]).to.eql(audioFilters)
     });
-    it('fails on non-FilterChain chains argument', () => {
+    it('allows adding a filter graph', () => {
+      const fg1 = new FilterGraph()
+      fg1.addFilterChain(videoFilters)
+      fg1.addFilterChain(audioFilters)
+      const fg2 = new FilterGraph()
+      fg2.addFilterGraph(fg1)
+      expect(fg2.chains.length).to.eql(2)
+      expect(fg2.chains[0]).to.eql(videoFilters)
+      expect(fg2.chains[1]).to.eql(audioFilters)
+    });
+    it('fails on non-FilterChain/FilterGraph chains argument', () => {
       expect(() => {
         const f = new FilterGraph()
         f.addFilterChain('abc')


### PR DESCRIPTION
This PR exposes the `FilterGraph` class at the library level and adds methods to add `FilterGraph` objects into other `FilterGraph`s by concatenating the `chains` property.

Added an extra test on `FilterGraph` testing basic functionality, but this likely needs another test or two before it's done.