### PR TITLE
Filter chain modify

### DIFF
--- a/lib/filter_chain.js
+++ b/lib/filter_chain.js
@@ -24,6 +24,22 @@ class FilterChain {
   }
 
   /**
+   * Append nodes to the FilterChain's nodes
+   * @param {...<FilterNode>} nodes - the filter nodes in the filter chain
+   */
+  appendNodes(...nodes) {
+    this.nodes = [...this.nodes, ...nodes];
+  }
+
+  /**
+   * Prepend nodes to the FilterChain's nodes
+   * @param {...<FilterNode>} nodes - the filter nodes in the filter chain
+   */
+  prependNodes(...nodes) {
+    this.nodes = [...nodes, ...this.nodes];
+  }
+
+  /**
    * Add inputs to the filter chain
    * @param {Array<FFmpegStreamSpecifier>} inputs - the input stream specifiers to connect to the chain
    * @returns {void}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tedconf/fessonia",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A node module easing the burden of automating ffmpeg from node.js",
   "main": "index.js",
   "publishConfig": {

--- a/test/filter_chain.test.js
+++ b/test/filter_chain.test.js
@@ -50,6 +50,34 @@ describe('FilterChain', () => {
     expect(() => fc.addInputs(['not a stream specifier'])).to.throw();
   });
 
+  describe('appendNodes()', () => {
+    it('adds additional nodes to the end of the nodes array', () => {
+      const chain = new FilterChain([cropFilter]);
+      chain.appendNodes(vflipFilter, splitFilter);
+      expect(chain.nodes).to.eql([cropFilter, vflipFilter, splitFilter]);
+    });
+
+    it('supports appending one node', () => {
+      const chain = new FilterChain([cropFilter]);
+      chain.appendNodes(vflipFilter);
+      expect(chain.nodes).to.eql([cropFilter, vflipFilter]);
+    });
+  });
+
+  describe('prependNodes()', () => {
+    it('adds additional nodes to the beginning of the nodes array', () => {
+      const chain = new FilterChain([cropFilter]);
+      chain.prependNodes(vflipFilter, splitFilter);
+      expect(chain.nodes).to.eql([vflipFilter, splitFilter, cropFilter]);
+    });
+
+    it('supports prepending one node', () => {
+      const chain = new FilterChain([cropFilter]);
+      chain.prependNodes(vflipFilter);
+      expect(chain.nodes).to.eql([vflipFilter, cropFilter]);
+    });
+  });
+
   describe('streamSpecifier()', () => {
     it('returns a streamSpecifer with the proper specifier', () => {
       const fc = new FilterChain(nodes);


### PR DESCRIPTION
adds support for appending and prepending nodes to FilterChains. This should make working with these objects a little simpler.