### PR TITLE
Live filter validation config setting

### DIFF
--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -3,6 +3,7 @@
  */
 
 const crypto = require('crypto');
+const fs = require('fs');
 const util = require('util');
 
 const config = new require('./util/config')();
@@ -299,26 +300,30 @@ class FilterNode {
   }
 
   /**
-   * Query the local installation of FFmpeg to get available filters
+   * Query the local installation of FFmpeg to get available filters (or pull from a fixture if live validation is off)
    *
    * @returns {Object} - an object of filter information for each available filter, keyed by filter name
    *
    * @private
    */
   static _queryFFmpegForFilters () {
-    const childProcess = require('child_process'),
-      execFileSync = childProcess.execFileSync;
-    let ffmpeg_binary = config.ffmpeg_bin,
-      ffmpeg_args = ['-filters'];
-    if (!ffmpeg_binary) {
-      throw new Error(`No ffmpeg binary found in config: '${ffmpeg_binary}'`);
+    if (config.live_validation) {
+      const childProcess = require('child_process'),
+        execFileSync = childProcess.execFileSync;
+      let ffmpeg_binary = config.ffmpeg_bin,
+        ffmpeg_args = ['-filters'];
+      if (!ffmpeg_binary) {
+        throw new Error(`No ffmpeg binary found in config: '${ffmpeg_binary}'`);
+      }
+      if (Array.isArray(ffmpeg_binary)) {
+        ffmpeg_binary = ffmpeg_binary[0];
+        ffmpeg_args = config.ffmpeg_bin.slice(1).concat(ffmpeg_args);
+      }
+      const out = execFileSync(ffmpeg_binary, ffmpeg_args, { stdio: 'pipe' });
+      return out;
     }
-    if (Array.isArray(ffmpeg_binary)) {
-      ffmpeg_binary = ffmpeg_binary[0];
-      ffmpeg_args = config.ffmpeg_bin.slice(1).concat(ffmpeg_args);
-    }
-    const out = execFileSync(ffmpeg_binary, ffmpeg_args, { stdio: 'pipe' });
-    return out;
+    const filtersFixture = fs.readFileSync(`${__dirname}/../test/fixtures/ffmpeg-filters.out`).toString();
+    return filtersFixture
   }
 
   /**

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -1,11 +1,13 @@
 const CONFIG_KEY = Symbol.for('FFmpegFiltergraph.Config');
 const debugFlag = process.env.DEBUG === 'true' || false;
 const logWarningsFlag = process.env.LOG_WARNINGS === 'true' || false;
+const liveValidationFlag = process.env.LIVE_VALIDATION === 'true' || process.env.NODE_ENV !== 'test' || false;
 const DEFAULTS = {
   ffmpeg_bin: 'ffmpeg',
   ffprobe_bin: 'ffprobe',
   debug: debugFlag,
   log_warnings: logWarningsFlag,
+  live_validation: liveValidationFlag,
   logger: require('./logger')({
     debugFlag: debugFlag,
     warnFlag: logWarningsFlag
@@ -34,14 +36,14 @@ const updateConfigWithOptions = function (options) {
 
 /**
  * Get the config object, optionally updated with new options
- * 
+ *
  * Options understood by this configuration object include:
  * * `ffmpeg_bin` - the location of your `ffmpeg` binary
  * * `ffprobe_bin` - the location of your `ffprobe` binary
- * 
+ *
  * @function
  * @param {Object} options - (optional) options object (default: {})
- * 
+ *
  * @returns {Object} - singleton object with config data
  */
 function getConfig (options = {}) {


### PR DESCRIPTION
Put live `ffmpeg`-based filter validation behind a config, and disable in test environment.

In addition to running into test environment problems when integrating into other apps, I've also run into this when working on the bug fix #24 for this library with an `ffmpeg` installation that didn't have the filter in question available. Quicker to just fix than to work around it.