### PR TITLE
Predictable node outputs

### DIFF
--- a/lib/ffmpeg_stream_specifier.js
+++ b/lib/ffmpeg_stream_specifier.js
@@ -48,8 +48,7 @@ class FFmpegStreamSpecifier {
       return `${this.entity.inputLabel}:${this.specifier}`;
     }
     if (this.entityType === 'FilterChain') {
-      const pad = this.entity.getOutputPad(this.specifier);
-      return `[chain${this.entity.position()}_${pad}]`;
+      return `[${this.entity.getOutputPad(this.specifier)}]`;
     }
     return this.specifier;
   }

--- a/lib/ffmpeg_stream_specifier.js
+++ b/lib/ffmpeg_stream_specifier.js
@@ -48,11 +48,8 @@ class FFmpegStreamSpecifier {
       return `${this.entity.inputLabel}:${this.specifier}`;
     }
     if (this.entityType === 'FilterChain') {
-      const s = this.entity.getOutputPad(this.specifier);
-      if (s.startsWith('[') && s.endsWith(']')) {
-        return s;
-      }
-      return `[${s}]`;
+      const pad = this.entity.getOutputPad(this.specifier);
+      return `[chain${this.entity.position()}_${pad}]`;
     }
     return this.specifier;
   }

--- a/lib/filter_chain.js
+++ b/lib/filter_chain.js
@@ -118,11 +118,11 @@ class FilterChain {
 
   /**
    * Get an output pad label on this filter chain
-   * @param {number|string|undefined} specifier - (optional) index/type of the output pad (default: next available pad)
+   * @param {string} specifier - the index from the requesting FFmpegStreamSpecifier
    * @returns {string} - the output pad label
    */
   getOutputPad (specifier) {
-    return this.outputNode.getOutputPad(specifier);
+    return `chain${this.position()}_${this.outputNode.getOutputPad(specifier)}`;
   }
 
   /**

--- a/lib/filter_chain.js
+++ b/lib/filter_chain.js
@@ -126,6 +126,19 @@ class FilterChain {
   }
 
   /**
+   * Get position of the filterChain in the filterGraph.
+   * If not in a graph, returns 0
+   * @returns {number} - the position of the chain in the graph
+   */
+  position () {
+    if (!this.filterGraph) {
+      return 0;
+    }
+
+    return this.filterGraph.chainPosition(this);
+  }
+
+  /**
    * Generate a string representation of the filter chain
    * @returns {string} - the filter chain string
    */
@@ -138,7 +151,9 @@ class FilterChain {
       return `[${str}]`;
     }).join('');
     let filters = this.nodes.map((f) => f.toString()).join(',');
-    let outputs = this.streamSpecifiers.map((specifier) => specifier.toString()).join('');
+    let outputs = this.streamSpecifiers.map(
+      (specifier) => specifier.toString()
+    ).join('');
     return `${inputs}${filters}${outputs}`;
   }
 

--- a/lib/filter_graph.js
+++ b/lib/filter_graph.js
@@ -45,7 +45,7 @@ class FilterGraph {
    */
   toString () {
     const s = this.chains
-      .map((fc, i) => fc.toString(i))
+      .map((fc) => fc.toString())
       .join(';');
     return s;
   }

--- a/lib/filter_graph.js
+++ b/lib/filter_graph.js
@@ -27,6 +27,16 @@ class FilterGraph {
       throw new Error('Invalid parameter chain: must be instance of FilterChain');
     }
     this.chains.push(chain);
+    chain.filterGraph = this;
+  }
+
+  /**
+   * Returns the position of the chain in the graph
+   * @param {FilterChain} chain - the filter chain to look for
+   * @returns {number} position of the chain in the graph
+   */
+  chainPosition(chain) {
+    return this.chains.findIndex((c) => c === chain);
   }
 
   /**
@@ -35,7 +45,7 @@ class FilterGraph {
    */
   toString () {
     const s = this.chains
-      .map((fc) => fc.toString())
+      .map((fc, i) => fc.toString(i))
       .join(';');
     return s;
   }

--- a/lib/filter_graph.js
+++ b/lib/filter_graph.js
@@ -1,6 +1,6 @@
 /**
  * @fileOverview lib/filter_graph.js - Defines and exports the FilterGraph class
- * 
+ *
  * @private
  */
 

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -20,7 +20,6 @@ class FilterNode {
     this.filterName = filterName;
     this.args = args;
 
-    this.padPrefix = `${filterName}_${this._digest(true).substring(0,12)}`;
     return this;
   }
 
@@ -38,28 +37,7 @@ class FilterNode {
    * @returns {string} - the output pad label
    */
   getOutputPad (specifier) {
-    return `${this.padPrefix}_${specifier}`;
-  }
-
-  /**
-   * Create MD5 hash of filter for pad prefix
-   * @param {boolean} salt - set true if digest should be salted for uniqueness (default: false)
-   * @returns {string} the hash string in hex of the filter
-   *
-   * @private
-   */
-  _digest (salt = false) {
-    let saltString = '';
-    if (salt) {
-      const B = 1000000000;
-      saltString += Date.now().toString();
-      saltString += Math.floor(B + B * Math.random()).toString();
-    }
-    const digest = crypto
-      .createHash('md5')
-      .update(this.toString() + saltString)
-      .digest('hex');
-    return (digest);
+    return `${this.filterName}_${specifier}`;
   }
 
   /**

--- a/test/ffmpeg_option.test.js
+++ b/test/ffmpeg_option.test.js
@@ -116,7 +116,7 @@ describe('FFmpegOption', function () {
           'filter',
           fg
         );
-        const expected = ['-filter_complex', `crop=iw:ih/2:0:0,split[${splitFilter.padPrefix}_0][${splitFilter.padPrefix}_1];[${splitFilter.padPrefix}_0]vflip;[${splitFilter.padPrefix}_1]vflip`];
+        const expected = ['-filter_complex', `crop=iw:ih/2:0:0,split[chain0_split_0][chain0_split_1];[chain0_split_0]vflip;[chain0_split_1]vflip`];
         expect(option.toCommandArray()).to.deep.eql(expected);
       });
     });
@@ -186,7 +186,7 @@ describe('FFmpegOption', function () {
           'filter',
           fg
         );
-        const expected = `-filter_complex crop=iw:ih/2:0:0,split[${splitFilter.padPrefix}_0][${splitFilter.padPrefix}_1];[${splitFilter.padPrefix}_0]vflip;[${splitFilter.padPrefix}_1]vflip`;
+        const expected = `-filter_complex crop=iw:ih/2:0:0,split[chain0_split_0][chain0_split_1];[chain0_split_0]vflip;[chain0_split_1]vflip`;
         expect(option.toCommandString()).to.deep.eql(expected);
       });
     });

--- a/test/ffmpeg_output.test.js
+++ b/test/ffmpeg_output.test.js
@@ -101,7 +101,7 @@ describe('FFmpegOutput', function () {
       const expectedLast = '/some/file.mp4';
       const expectedArgs = [
         ['-dn'],
-        ['-filter_complex', `crop=iw:ih/2:0:0,split[${splitFilter.padPrefix}_0][${splitFilter.padPrefix}_1];[${splitFilter.padPrefix}_0]vflip[${vflipFilter.padPrefix}_0];[${splitFilter.padPrefix}_1]hflip[${hflipFilter.padPrefix}_0]`],
+        ['-filter_complex', `crop=iw:ih/2:0:0,split[chain0_split_0][chain0_split_1];[chain0_split_0]vflip[chain1_vflip_0];[chain0_split_1]hflip[chain2_hflip_0]`],
         ['-b:v', '3850k'],
         ['-f', 'mp4'],
         ['-aspect', '16:9']
@@ -184,7 +184,7 @@ describe('FFmpegOutput', function () {
       expect(fo.streams.length).to.eql(1);
       expect(fo.streams).to.deep.eql([ videoStream ]);
       expect(fo.toCommandArray()).to.deep.eql([
-        '-map', `[${node.padPrefix}_0]`,
+        '-map', `[chain0_scale_0]`,
         '/some/file.mp4'
       ]);
     });
@@ -216,14 +216,14 @@ describe('FFmpegOutput', function () {
       const fc1 = new FilterChain([node1]);
       const fc2 = new FilterChain([node2]);
       const stream1 = fc1.streamSpecifier(0);
-      const stream2 = fc2.streamSpecifier(0)
+      const stream2 = fc2.streamSpecifier(0);
       fo.addStream(stream1);
       fo.addStream(stream2);
       expect(fo.streams.length).to.eql(2);
       expect(fo.streams).to.deep.eql([ stream1, stream2 ]);
       expect(fo.toCommandArray()).to.deep.eql([
-        '-map', `[${node1.padPrefix}_0]`,
-        '-map', `[${node2.padPrefix}_0]`,
+        '-map', `[chain0_scale_0]`,
+        '-map', `[chain0_vflip_0]`,
         '/some/file.mp4'
       ]);
     });

--- a/test/ffmpeg_stream_specifier.test.js
+++ b/test/ffmpeg_stream_specifier.test.js
@@ -34,10 +34,10 @@ describe('FFmpegStreamSpecifier', () => {
   });
   describe('toString()', () => {
     it('returns the correct stream specifier for a FilterChain', () => {
-      const s1 = new FFmpegStreamSpecifier(filterChain, 0)
-      expect(s1.toString()).to.eql(`[${splitFilter.padPrefix}_0]`)
-      const s2 = new FFmpegStreamSpecifier(filterChain, 1)
-      expect(s2.toString()).to.eql(`[${splitFilter.padPrefix}_1]`)
+      const s1 = new FFmpegStreamSpecifier(filterChain, 0);
+      expect(s1.toString()).to.eql(`[chain0_split_0]`);
+      const s2 = new FFmpegStreamSpecifier(filterChain, 1);
+      expect(s2.toString()).to.eql(`[chain0_split_1]`);
     });
     it('returns the correct stream specifier for an FFmpegInput', () => {
       const s1 = new FFmpegStreamSpecifier(ffmpegInput, 1)

--- a/test/filter_chain.test.js
+++ b/test/filter_chain.test.js
@@ -86,7 +86,7 @@ describe('FilterChain', () => {
   describe('getOutputPad()', () => {
     it('returns the requested output pad label', () => {
       const fc = new FilterChain(nodes);
-      expect(fc.getOutputPad(0)).to.eql(`${splitFilter.padPrefix}_0`);
+      expect(fc.getOutputPad(0)).to.eql(`split_0`);
     })
   });
   describe('toString()', () => {

--- a/test/filter_graph.test.js
+++ b/test/filter_graph.test.js
@@ -58,6 +58,12 @@ describe('FilterGraph', function () {
         f.addFilterChain('abc')
       }).to.throw();
     });
+    it('sets filterGraph on the chain', () => {
+      expect(videoFilters.filterGraph).to.be.undefined;
+      const fg = new FilterGraph();
+      fg.addFilterChain(videoFilters);
+      expect(videoFilters.filterGraph).to.eql(fg);
+    });
   })
   describe('toString()', () => {
     it('returns the correct string representation', () => {
@@ -68,6 +74,16 @@ describe('FilterGraph', function () {
       delayedAudio.inputLabel = 1
       const expected = `[0:v]scale=640:-1,subtitles=filename=subtitles.srt;[1:a]alimiter=limit=0.8,atadenoise=s=31`
       expect(fg.toString()).to.eql(expected)
+    });
+  });
+
+  describe('chainPosition()', () => {
+    it('should return the position of the requested chain', () => {
+      const fg = new FilterGraph();
+      fg.addFilterChain(videoFilters);
+      fg.addFilterChain(audioFilters);
+      expect(fg.chainPosition(videoFilters)).to.eql(0);
+      expect(fg.chainPosition(audioFilters)).to.eql(1);
     });
   });
 

--- a/test/filter_graph.test.js
+++ b/test/filter_graph.test.js
@@ -68,6 +68,23 @@ describe('FilterGraph', function () {
       delayedAudio.inputLabel = 1
       const expected = `[0:v]scale=640:-1,subtitles=filename=subtitles.srt;[1:a]alimiter=limit=0.8,atadenoise=s=31`
       expect(fg.toString()).to.eql(expected)
-    })
-  })
+    });
+  });
+
+  describe('multiple nodes of the same name', () => {
+    it('should not create naming collisions', () => {
+      const vflip1 = new FilterNode('vflip');
+      const chain1 = new FilterChain([vflip1]);
+      const vflip2 = new FilterNode('vflip');
+      const chain2 = new FilterChain([vflip2]);
+      chain2.addInput(chain1.streamSpecifier());
+      chain2.streamSpecifier();
+
+      const graph = new FilterGraph;
+      graph.addFilterChain(chain1);
+      graph.addFilterChain(chain2);
+
+      expect(graph.toString()).to.eql('vflip[chain0_vflip_0];[chain0_vflip_0]vflip[chain1_vflip_0]');
+    });
+  });
 });

--- a/test/filter_node.test.js
+++ b/test/filter_node.test.js
@@ -20,10 +20,6 @@ describe('FilterNode', function () {
     let f = new FilterNode(filterName, { parity: 'tff' });
     expect(f.args).to.deep.eql(filterArgs);
   });
-  it('creates a unique pad prefix', function () {
-    let f1 = new FilterNode(filterName, filterArgs);
-    expect(f1.padPrefix).to.be.a('string');
-  });
   // array-only arguments
   it('generates the correct arguments string representation for array-only arguments', function () {
     let f1 = new FilterNode('scale', [1920, 1080]);
@@ -38,5 +34,13 @@ describe('FilterNode', function () {
   it('generates the correct arguments string representation for mixed arguments', function () {
     let f = new FilterNode('crop', [{ x: 12, y: 34 }, 100, 100 ]);
     expect(f.toString()).to.deep.eql('crop=100:100:x=12:y=34');
+  });
+
+  describe('getOutputPad', () => {
+    it('should return a string based on the filterName and specifier provided', () => {
+      const node = new FilterNode('yadif');
+      expect(node.getOutputPad(0)).to.eql('yadif_0');
+      expect(node.getOutputPad(3)).to.eql('yadif_3');
+    });
   });
 });


### PR DESCRIPTION
It's bothered me for a bit that ffmpeg commands generated with filter nodes and output pads are not consistent across runs. This makes testing ffmpeg command output more difficult than it should be.

What does this PR do? It allows filterChains to understand their position within the graph and produce output pad labels which are consistent across the same run of the command. This guarantees that no chains share output pad labels, but makes the labels predictable and reliable across multiple runs.