### PR TITLE
Fix TypeScript definition module kind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,12 @@
       "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "dev": true
+    },
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
@@ -3305,6 +3311,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
       "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "generate-docs": "scripts/generate-docs.sh",
     "add-contributor": "./node_modules/.bin/all-contributors add",
     "check-contributors": "./node_modules/.bin/all-contributors check",
-    "generate-contributors": "./node_modules/.bin/all-contributors generate"
+    "generate-contributors": "./node_modules/.bin/all-contributors generate",
+    "check-typings": "tsc --noEmit --strict --lib es6 types/index.d.ts"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
   },
   "homepage": "https://tedconf.github.io/fessonia",
   "devDependencies": {
+    "@types/node": "^14.14.37",
     "all-contributors-cli": "^6.17.0",
     "c8": "^7.3.0",
     "chai": "^4.2.0",
@@ -54,6 +56,7 @@
     "jsdoc": "^3.6.3",
     "mocha": "^7.1.2",
     "sinon": "^7.1.1",
-    "tui-jsdoc-template": "^1.2.2"
+    "tui-jsdoc-template": "^1.2.2",
+    "typescript": "^4.2.3"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,14 +1,15 @@
 import { FessoniaConfig } from './lib/util/config';
-import FFmpegCommand from './lib/ffmpeg_command';
-import FFmpegInput from './lib/ffmpeg_input';
-import FFmpegOutput from './lib/ffmpeg_output';
-import FilterChain from './lib/filter_chain';
-import FilterNode from './lib/filter_node';
+import type FFmpegCommand = require('./lib/ffmpeg_command');
+import type FFmpegError = require('./lib/ffmpeg_error');
+import type FFmpegInput = require('./lib/ffmpeg_input');
+import type FFmpegOutput = require('./lib/ffmpeg_output');
+import type FilterChain = require('./lib/filter_chain');
+import type FilterNode = require('./lib/filter_node');
 
 /** Main function interface to the library. Returns object of classes when called. */
-export default function getFessonia(opts?: Partial<Fessonia.ConfigOpts>): Fessonia;
+declare function Fessonia(opts?: Partial<Fessonia.ConfigOpts>): Fessonia;
 
-export interface Fessonia {
+interface Fessonia {
   FFmpegCommand: typeof FFmpegCommand;
   FFmpegInput: typeof FFmpegInput;
   FFmpegOutput: typeof FFmpegOutput;
@@ -16,22 +17,17 @@ export interface Fessonia {
   FilterNode: typeof FilterNode;
 }
 
-// re-export only types (i.e., not constructors) to prevent direct instantiation
-import type FFmpegCommandType from './lib/ffmpeg_command';
-import type FFmpegError from './lib/ffmpeg_error';
-import type FFmpegInputType from './lib/ffmpeg_input';
-import type FFmpegOutputType from './lib/ffmpeg_output';
-import type FilterNodeType from './lib/filter_node';
-import type FilterChainType from './lib/filter_chain';
-export namespace Fessonia {
+declare namespace Fessonia {
     export type ConfigOpts = Partial<FessoniaConfig>;
 
     export {
-      FFmpegCommandType as FFmpegCommand,
+      FFmpegCommand,
       FFmpegError,
-      FFmpegInputType as FFmpegInput,
-      FFmpegOutputType as FFmpegOutput,
-      FilterChainType as FilterChain,
-      FilterNodeType as FilterNode,
+      FFmpegInput,
+      FFmpegOutput,
+      FilterChain,
+      FilterNode,
     };
 }
+
+export = Fessonia;

--- a/types/lib/ffmpeg_command.d.ts
+++ b/types/lib/ffmpeg_command.d.ts
@@ -5,7 +5,7 @@ import FFmpegOutput from './ffmpeg_output';
 import FilterChain from './filter_chain';
 import FilterGraph from './filter_graph';
 
-export default FFmpegCommand;
+export = FFmpegCommand;
 
 /** Class representing an FFmpeg command (`ffmpeg ...`) */
 declare class FFmpegCommand extends EventEmitter {

--- a/types/lib/ffmpeg_command.d.ts
+++ b/types/lib/ffmpeg_command.d.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 import { ChildProcessWithoutNullStreams } from 'child_process';
-import FFmpegInput from './ffmpeg_input';
-import FFmpegOutput from './ffmpeg_output';
-import FilterChain from './filter_chain';
-import FilterGraph from './filter_graph';
+import FFmpegInput = require('./ffmpeg_input');
+import FFmpegOutput = require('./ffmpeg_output');
+import FilterChain = require('./filter_chain');
+import FilterGraph = require('./filter_graph');
 
 export = FFmpegCommand;
 

--- a/types/lib/ffmpeg_error.d.ts
+++ b/types/lib/ffmpeg_error.d.ts
@@ -1,6 +1,6 @@
 import FFmpegProgressEmitter from './ffmpeg_progress_emitter';
 
-export default FFmpegError;
+export = FFmpegError;
 
 interface FFmpegError extends Error {
     /** the FFmpeg command string that was executed */

--- a/types/lib/ffmpeg_error.d.ts
+++ b/types/lib/ffmpeg_error.d.ts
@@ -1,4 +1,4 @@
-import FFmpegProgressEmitter from './ffmpeg_progress_emitter';
+import FFmpegProgressEmitter = require('./ffmpeg_progress_emitter');
 
 export = FFmpegError;
 

--- a/types/lib/ffmpeg_input.d.ts
+++ b/types/lib/ffmpeg_input.d.ts
@@ -1,8 +1,8 @@
-import FFmpegOption from './ffmpeg_option';
-import FilterChain from './filter_chain';
-import FilterGraph from './filter_graph';
-import FilterNode from './filter_node';
-import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
+import FFmpegOption = require('./ffmpeg_option');
+import FilterChain = require('./filter_chain');
+import FilterGraph = require('./filter_graph');
+import FilterNode = require('./filter_node');
+import FFmpegStreamSpecifier = require('./ffmpeg_stream_specifier');
 
 export = FFmpegInput;
 

--- a/types/lib/ffmpeg_input.d.ts
+++ b/types/lib/ffmpeg_input.d.ts
@@ -4,7 +4,7 @@ import FilterGraph from './filter_graph';
 import FilterNode from './filter_node';
 import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
 
-export default FFmpegInput;
+export = FFmpegInput;
 
 /** Class representing an FFmpeg input file (`-i`) */
 declare class FFmpegInput {

--- a/types/lib/ffmpeg_option.d.ts
+++ b/types/lib/ffmpeg_option.d.ts
@@ -1,6 +1,6 @@
-import FilterChain from './filter_chain';
-import FilterGraph from './filter_graph';
-import FilterNode from './filter_node';
+import FilterChain = require('./filter_chain');
+import FilterGraph = require('./filter_graph');
+import FilterNode = require('./filter_node');
 
 export = FFmpegOption;
 

--- a/types/lib/ffmpeg_option.d.ts
+++ b/types/lib/ffmpeg_option.d.ts
@@ -2,7 +2,7 @@ import FilterChain from './filter_chain';
 import FilterGraph from './filter_graph';
 import FilterNode from './filter_node';
 
-export default FFmpegOption;
+export = FFmpegOption;
 
 /**
  * Class representing an FFmpeg option

--- a/types/lib/ffmpeg_output.d.ts
+++ b/types/lib/ffmpeg_output.d.ts
@@ -1,7 +1,7 @@
 import FFmpegOption from './ffmpeg_option';
 import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
 
-export default FFmpegOutput;
+export = FFmpegOutput;
 
 /** Class representing an FFmpeg output file */
 declare class FFmpegOutput {

--- a/types/lib/ffmpeg_output.d.ts
+++ b/types/lib/ffmpeg_output.d.ts
@@ -1,5 +1,5 @@
-import FFmpegOption from './ffmpeg_option';
-import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
+import FFmpegOption = require('./ffmpeg_option');
+import FFmpegStreamSpecifier = require('./ffmpeg_stream_specifier');
 
 export = FFmpegOutput;
 

--- a/types/lib/ffmpeg_progress_emitter.d.ts
+++ b/types/lib/ffmpeg_progress_emitter.d.ts
@@ -1,6 +1,6 @@
 import { Writable, WritableOptions } from 'stream';
 
-export default FFmpegProgressEmitter;
+export = FFmpegProgressEmitter;
 
 /**
  * A class that implements a progress event emitter for FFmpegCommand executions

--- a/types/lib/ffmpeg_stream_specifier.d.ts
+++ b/types/lib/ffmpeg_stream_specifier.d.ts
@@ -1,5 +1,5 @@
-import FFmpegInput from './ffmpeg_input';
-import FilterChain from './filter_chain';
+import FFmpegInput = require('./ffmpeg_input');
+import FilterChain = require('./filter_chain');
 
 export = FFmpegStreamSpecifier;
 

--- a/types/lib/ffmpeg_stream_specifier.d.ts
+++ b/types/lib/ffmpeg_stream_specifier.d.ts
@@ -1,7 +1,7 @@
 import FFmpegInput from './ffmpeg_input';
 import FilterChain from './filter_chain';
 
-export default FFmpegStreamSpecifier;
+export = FFmpegStreamSpecifier;
 
 /**
  * Class representing an FFmpeg stream specifier

--- a/types/lib/filter_chain.d.ts
+++ b/types/lib/filter_chain.d.ts
@@ -1,7 +1,7 @@
 import FilterNode from './filter_node'
 import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
 
-export default FilterChain;
+export = FilterChain;
 
 type ArrayOfOneOrMore<T> = [T, ...T[]];
 

--- a/types/lib/filter_chain.d.ts
+++ b/types/lib/filter_chain.d.ts
@@ -1,5 +1,5 @@
-import FilterNode from './filter_node'
-import FFmpegStreamSpecifier from './ffmpeg_stream_specifier';
+import FilterNode = require('./filter_node');
+import FFmpegStreamSpecifier = require('./ffmpeg_stream_specifier');
 
 export = FilterChain;
 

--- a/types/lib/filter_graph.d.ts
+++ b/types/lib/filter_graph.d.ts
@@ -1,5 +1,5 @@
-import FilterChain from './filter_chain';
-import FilterNode from './filter_node';
+import FilterChain = require('./filter_chain');
+import FilterNode = require('./filter_node');
 
 export = FilterGraph;
 

--- a/types/lib/filter_graph.d.ts
+++ b/types/lib/filter_graph.d.ts
@@ -1,7 +1,7 @@
 import FilterChain from './filter_chain';
 import FilterNode from './filter_node';
 
-export default FilterGraph;
+export = FilterGraph;
 
 /** Class representing an FFmpeg filter graph */
 declare class FilterGraph {

--- a/types/lib/filter_node.d.ts
+++ b/types/lib/filter_node.d.ts
@@ -1,4 +1,4 @@
-export default FilterNode;
+export = FilterNode;
 
 declare class FilterNode {
     args: FilterNode.Argument[];


### PR DESCRIPTION
The TypeScript definitions represented this library as using ES modules, which it does not—it uses CommonJS modules. This made them unusable by anyone trying to `require("@tedconf/fessonia")` instead of `import`ing it.

As an aside, would you be open to moving these definitions to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)? Normally, if a library is written in TypeScript, it ships its own definitions (usually generated from the implementation code) from the repo, but if a library is written in JS, the community contributes its type definitions on DefinitelyTyped. The review and publishing process there is streamlined to make it easy for TypeScript users who want to use your library to contribute, and the reviewers are experts who could catch mistakes like this module mixup (which is an extremely common and easy mistake to make). If you’re not personally interested in maintaining these definitions alongside the source code, it may be easier both for you and for your users to let the TS community work on them in parallel. But it’s just a suggestion; it’s your call.

(Source: I work on the TypeScript team and help maintain DefinitelyTyped.)